### PR TITLE
Update apache_install.yaml

### DIFF
--- a/rhel/apache/apache_install.yml
+++ b/rhel/apache/apache_install.yml
@@ -1,6 +1,6 @@
 ---
 - name: Apache server installed
-  hosts: web
+  hosts: all
 
   tasks:
   - name: latest Apache version installed


### PR DESCRIPTION
previous version does not work in workshop, it was different from workshop text.
(if this error is intentional error, workshop attendee will learn how to debug, for example, ignore this PR)